### PR TITLE
Port documentation from cdc-2024

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- Created by SQL Sith in 2024 -->
+
 # Contributing to this repo
 
 The general workflow for contributing to this repo is straightforward:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- Created by SQL Sith in 2024 -->
+
 # Cedar Rapids Area Homeschools
 
 ## IT Club Cyber Defense, 2024-2025 season

--- a/documentation/iseage/AddingAProxyForDocker.md
+++ b/documentation/iseage/AddingAProxyForDocker.md
@@ -1,0 +1,49 @@
+# Adding A Proxy For Docker
+In this document we will cover setting up docker to work though the WiErd and StrAnge iseage proxy.
+
+## Method 1: use systemd
+
+1) Create a config folder (root):
+	```sh
+ 	mkdir -p /etc/systemd/system/docker.service.d
+ 	```
+ 2) Create a proxy config (root):
+	```sh
+ 	touch /etc/systemd/system/docker.service.d/http-proxy.conf
+ 	```
+ 3) Add the proxy info to the above file (root):  
+	(Add these lines to it:)
+	```ini
+ 	[Service]
+	Environment="HTTP_PROXY=http://199.100.16.100:3128"
+	Environment="HTTPS_PROXY=http://199.100.16.100:3128"
+	Environment="NO_PROXY=localhost,127.0.0.1"
+ 	```
+ 4) Restart docker (root):
+	```sh
+ 	systemctl daemon-reload
+	systemctl restart docker
+ 	```
+ 5) Make sure everything is working:
+	```sh
+ 	docker info | grep Proxy
+ 	```
+ 	If this matches the text in step 3 well enough, we are done.
+	If not, this incident will be reported.
+
+## Method 2: add some docker config
+
+1) Open `~/.docker/config.json`
+2) Make sure the following structure is in the file:
+	```json
+	{
+	 "proxies": {
+	   "default": {
+	     "httpProxy": "http://199.100.16.100:3128",
+	     "httpsProxy": "http://199.100.16.100:3128",
+	     "noProxy": "localhost,127.0.0.1"
+	   }
+	 }
+	}
+	```
+ 3) Hope it works.

--- a/documentation/iseage/README.md
+++ b/documentation/iseage/README.md
@@ -1,3 +1,4 @@
+<!-- Created by SQL Sith in 2024 -->
 <!-- cspell: ignore Iseage -->
 
 # Iseage documentation

--- a/documentation/iseage/README.md
+++ b/documentation/iseage/README.md
@@ -1,3 +1,18 @@
-# Placeholder file
+<!-- cspell: ignore Iseage -->
 
-This README is a placeholder file so that GitHub will create its parent directory.
+# Iseage documentation
+
+Iseage is the tool we will be using to host virtual machines.
+
+This folder will be used to hold documentation on using iseage.
+
+## Table of Contents
+
+|Document         |
+|-----------------|
+|[Adding a proxy to docker](./AddingAProxyForDocker.md)
+|[Setting up a proxy for Ubuntu desktop](./SettingUpProxyForUbuntuDesktop.md)|
+|[Setting up a proxy for Ubuntu server](./SettingUpProxyForUbuntuServer.md)|
+|[Setting up a proxy for Windows 10](./SettingUpProxyForWindows10.md)|
+
+> if you create documentation for Iseage, please link to it in the above table

--- a/documentation/iseage/SettingUpProxyForUbuntuDesktop.md
+++ b/documentation/iseage/SettingUpProxyForUbuntuDesktop.md
@@ -1,0 +1,42 @@
+# Setting a Proxy for Ubuntu Desktop
+
+## Values
+
+**PROXY:** `199.100.16.100:3128`  
+**GATEWAY:** `144.76.90.254`  
+**YOURSELF:** `144.76.90.???/24`
+
+When we say `{YOU}`, please consult the team and come up with a unique number between 7 and 250 (inclusive) to put there.
+> Please maintain a single `{YOU}` per server.
+
+## Instructions
+
+1. Open Settings>Network>Wired>Settings Icon
+    1. Chose IPv4 tab
+    2. For IPv4 Method, choose Manual
+    3. Set Addresses>Address to 144.76.90.`{YOU}`
+    4. Set Addresses>Netmask to 255.255.255.0
+    5. Set Addresses>Gateway to 144.76.90.254
+2. Settings>Network>Network Proxy>Settings Icon
+    1. Choose Manual
+    2. HTTP Proxy (Left box) 199.100.16.100
+    3. HTTP Proxy (Right box): 3128
+    4. HTTPS Proxy (Left box) 199.100.16.100
+    5. HTTPS Proxy (Right box): 3128
+    6. FTP Proxy (Left box) 199.100.16.100
+    7. FTP Proxy (Right box): 3128
+    8. Socks Host (Left box) 199.100.16.100
+    9. Socks Host (Right box): 3128
+3. Set `/etc/apt/apt.conf`'s contents to the following:
+    ```
+    Acquire::http::Proxy "http://199.100.16.100:3128";
+    Acquire::https::Proxy "http://199.100.16.100:3128";
+    ```
+4. Restart the machine
+5. `apt`, `curl` and `wget` should now be working.  
+	Verify this by running the following:
+	| Program to Test | Command to Run                           |
+	|:---------------:|------------------------------------------|
+	|      `apt`      | `sudo apt update && sudo apt upgrade -y` |
+	|     `curl`      | `curl google.com`                        |
+	|     `wget`      | `wget google.com`                        |

--- a/documentation/iseage/SettingUpProxyForUbuntuDesktop.md
+++ b/documentation/iseage/SettingUpProxyForUbuntuDesktop.md
@@ -1,3 +1,5 @@
+<!-- Created by Aksel Rasmussen in 2024 -->
+
 # Setting a Proxy for Ubuntu Desktop
 
 ## Values

--- a/documentation/iseage/SettingUpProxyForUbuntuServer.md
+++ b/documentation/iseage/SettingUpProxyForUbuntuServer.md
@@ -1,0 +1,52 @@
+# Connecting to the outside world from ISEAGE
+
+> Created by Aksel Rasmussen on 2023-10-14
+> Last updated by Aksel Rasmussen on 2024-02-21 at 14:43
+
+> NOTE: These instructions are for use with an unmodified install of Ubuntu Server.
+> If you have any issues outside of that, that's your fault.
+
+1) Open `/etc/netplan/00-installer-config.yml`
+2) Change what `ethernets:{yourEthernet}` says to:
+	```
+	{your ethernet}:
+	  dhcp4: no
+	  addresses: [144.76.90.{num}/24]
+	  routes:
+	   - to: default
+	     via: 144.76.90.254
+	  nameservers:
+	    addresses: [144.76.90.254]
+	```
+	> Replace `{num}` with a unique number from `1` to `253`.
+3) Add the following lines to the end of `/etc/profile`:
+	```sh
+	export http_proxy=http://199.100.16.100:3128
+	export https_proxy=http://199.100.16.100:3128
+	export ftp_proxy=http://199.100.16.100:3128
+	```
+4) Set `/etc/apt/apt.conf`'s contents to the following:
+	```
+	Acquire::http::Proxy "http://199.100.16.100:3128";
+	Acquire::https::Proxy "http://199.100.16.100:3128";
+	```
+5) Run `sudo netplan apply`
+6) Append the following to `/etc/wgetrc`:
+	```
+	use_proxy=yes
+	http_proxy=199.100.16.100:3128
+	https_proxy=199.100.16.100:3128
+	```
+7) Restart the machine
+8) `apt`, `curl` and `wget` should now be working.  
+	Verify this by running the following:
+	| Program to Test | Command to Run                           |
+	|:---------------:|------------------------------------------|
+	|      `apt`      | `sudo apt update && sudo apt upgrade -y` |
+	|     `curl`      | `curl google.com`                        |
+	|     `wget`      | `wget google.com`                        |
+
+> Currently known issues:
+> - `dig` isn't working
+> - `nslookup` isn't working
+> - `named` can't forward its requests

--- a/documentation/iseage/SettingUpProxyForUbuntuServer.md
+++ b/documentation/iseage/SettingUpProxyForUbuntuServer.md
@@ -1,3 +1,5 @@
+<!-- Created by Aksel Rasmussen in 2023 -->
+
 # Connecting to the outside world from ISEAGE
 
 > Created by Aksel Rasmussen on 2023-10-14

--- a/documentation/iseage/SettingUpProxyForWindows10.md
+++ b/documentation/iseage/SettingUpProxyForWindows10.md
@@ -1,0 +1,41 @@
+# Windows 10 Proxy Settings
+
+A guide for setting up Windows 10 on Iserink with internet.
+
+> ### !!WARNING!!
+> DO NOT give Windows internet access until setup is complete, or it will give you a worse experiance.
+> NOBODY IN THEIR RIGHT MIND wants a worse experiance.
+> Please DON'T let windows kill you.
+> PLEASE.
+
+> ### A Quick note before we begin
+> Wish we were younger.
+> This guide is based on Win10.
+> It may work with Win11 and 12, but I don't care.
+> It is also based on a fresh install.
+> If it doesn't work on your machine, it works on mine, so get over it.
+> If you feel like reinstalling windows will make it work better, than do that.
+
+## Setup
+
+1. Navigate: Settings > Network & Internet > Ethernet.
+2. Click the network. It should be called somthing like "Unidetified network".
+3. Under "IP settings", press the "Edit" button.
+4. In the dialog that pops up, change the dropdown from "Automatic (DHCP)" to "Manual".
+5. Turn on the "IPv4" switch.
+6. Set "IP address" to a free address in the form "144.76.90.*". Check with the team for which addresses are available.
+7. Set "Subnet prefix length" to "24".
+8. Set "Gateway" to "144.76.90.254".
+9. Ignore the DNS boxes and press the "Save button".
+10. Navigate: Settings > Network & Internet > Proxy.
+11. Under "Automatic proxy setup", turn off "Automatically detect settings".
+12. Under "Manual proxy setup", turn on "Use a proxy server".
+13. Set "Address" to "199.100.16.100".
+14. Set "Port" to "3128".
+15. Press the "Save" button.
+
+## Verifying the Proxy
+
+1. In a webbrowser, go to your favourite external website. (eg. not google)
+2. If it loads, you got it.
+3. If it doesn't load, that's your problem. Go reread the guide, esp the top part.

--- a/documentation/iseage/SettingUpProxyForWindows10.md
+++ b/documentation/iseage/SettingUpProxyForWindows10.md
@@ -1,3 +1,5 @@
+<!-- Created by Aksel Rasmussen in 2024 -->
+
 # Windows 10 Proxy Settings
 
 A guide for setting up Windows 10 on Iserink with internet.

--- a/documentation/repo/README.md
+++ b/documentation/repo/README.md
@@ -1,3 +1,5 @@
+<!-- Created by SQL Sith in 2024 -->
+
 # Placeholder file
 
 This README is a placeholder file so that GitHub will create its parent directory.

--- a/images/README.md
+++ b/images/README.md
@@ -1,3 +1,5 @@
+<!-- Created by SQL Sith in 2024 -->
+
 # Placeholder file
 
 This README is a placeholder file so that GitHub will create its parent directory.

--- a/src/README.md
+++ b/src/README.md
@@ -1,3 +1,5 @@
+<!-- Created by SQL Sith in 2024 -->
+
 # Placeholder file
 
 This README is a placeholder file so that GitHub will create its parent directory.


### PR DESCRIPTION
- Copied all documents from [cdc-2024](https://github.com/sql-sith/cdc-2024) I deemed relevant (those being the iseage proxy docs)
- Repurposed the [docs/iseage readme](docs/iseage/readme.md) from a placeholder file to a ToC
- Added credit to some documents (not sure if this is a good change) (this should have been a seperate PR)